### PR TITLE
Fix patchset number from Gerrit

### DIFF
--- a/zuul/model.py
+++ b/zuul/model.py
@@ -910,7 +910,7 @@ class Changeish(object):
         base_path = ''
         if hasattr(self, 'refspec'):
             base_path = "%s/%s/%s" % (
-                self.number[-2:], self.number, self.patchset)
+                str(self.number)[-2:], self.number, self.patchset)
         elif hasattr(self, 'ref'):
             base_path = "%s/%s" % (self.newrev[:2], self.newrev)
 


### PR DESCRIPTION
The patchset number is now received as a integer instead of a string,
therefore it cannot be enumerated.